### PR TITLE
.eslintrc set arrow-body-style to as-needed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
     "max-len": [2, 140, 2, {"ignoreComments": true, "ignoreTrailingComments": true}],
     "no-param-reassign": 0,
     "one-var": 0,
-    "quote-props": [2, "as-needed", { keywords: false, unnecessary: true, numbers: false }]
+    "quote-props": [2, "as-needed", { keywords: false, unnecessary: true, numbers: false }],
+    "arrow-body-style": [2, "as-needed"]
   },
   "env": {
     "node": true


### PR DESCRIPTION
To allow:

```
# formatMoney.js 
return map(number, (val) => formatMoney(val, opts));
```
Instead of 

```
# formatMoney.js 
return map(number, (val) => { return formatMoney(val, opts); });
```