### PR TITLE
[package.json] fixes #17: move babel-preset-es2015-rollup to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "ava": "^0.12.0",
     "babel-eslint": "^5.0.0",
-    "babel-preset-es2015-rollup": "^1.1.0",
     "esdoc": "^0.4.5",
     "eslint": "^2.2.0",
     "eslint-config-nashdot": "^1.1.0",
@@ -62,6 +61,7 @@
     "source-map-support": "^0.4.0"
   },
   "dependencies": {
+    "babel-preset-es2015-rollup": "^1.1.0",
     "is-string": "^1.0.4",
     "object-assign": "^4.0.1"
   },


### PR DESCRIPTION
This change fixes #17 where the a necessary preset is not downloaded, causing an exception to be thrown when code is run through UglifyJS (via webpack).